### PR TITLE
Adding Spring properties integration to handle configuration

### DIFF
--- a/zipkin-datadog-reporter-autoconfigure/src/main/java/io/smartup/zipkin/DatadogProperties.java
+++ b/zipkin-datadog-reporter-autoconfigure/src/main/java/io/smartup/zipkin/DatadogProperties.java
@@ -1,0 +1,43 @@
+package io.smartup.zipkin;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.zipkin.datadog")
+public class DatadogProperties {
+
+    /**
+     * Host of the Datadog agent
+     */
+    private String host = "localhost";
+
+    /**
+     * Port the Datadog agent is listening on
+     */
+    private int port = 8126;
+
+    /**
+     * Enables sending spans to Datadog
+     */
+    private boolean enabled = true;
+
+    /**
+     * Timeout in seconds before pending spans will be sent in batches to Zipkin
+     */
+    private int messageTimeout = 1;
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getMessageTimeout() {
+        return messageTimeout;
+    }
+}

--- a/zipkin-datadog-reporter-autoconfigure/src/main/java/io/smartup/zipkin/ZipkinDatadogReporterAutoConfiguration.java
+++ b/zipkin-datadog-reporter-autoconfigure/src/main/java/io/smartup/zipkin/ZipkinDatadogReporterAutoConfiguration.java
@@ -1,17 +1,24 @@
 package io.smartup.zipkin;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.sleuth.sampler.SamplerProperties;
 import org.springframework.cloud.sleuth.zipkin2.ZipkinAutoConfiguration;
+import org.springframework.cloud.sleuth.zipkin2.ZipkinProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
 @Configuration
+@EnableConfigurationProperties(ZipkinProperties.class)
+@ConditionalOnProperty(value = "spring.zipkin.datadog.enabled", matchIfMissing = true)
 @AutoConfigureBefore(ZipkinAutoConfiguration.class)
 public class ZipkinDatadogReporterAutoConfiguration {
+
     @Bean
-    public Reporter<Span> reporter() {
-        return new DatadogReporter();
+    public Reporter<Span> reporter(DatadogProperties properties) {
+        return new DatadogReporter(properties.getHost(), properties.getPort(), properties.getMessageTimeout());
     }
 }

--- a/zipkin-datadog-reporter-core/src/main/java/io/smartup/zipkin/DDApi.java
+++ b/zipkin-datadog-reporter-core/src/main/java/io/smartup/zipkin/DDApi.java
@@ -18,8 +18,6 @@ import java.util.concurrent.TimeUnit;
  * The API pointing to a DD agent
  */
 class DDApi {
-    static final String DEFAULT_HOSTNAME = "localhost";
-    static final int DEFAULT_PORT = 8126;
     static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
     static final String JAVA_VM_NAME = System.getProperty("java.vm.name", "unknown");
     private static final Logger log = LoggerFactory.getLogger(DDApi.class);


### PR DESCRIPTION
This change allows external configuration of the Datadog reporter, with most of the properties and their namespaces hijacked from the Zipkin reporter's in Spring Sleuth.

BTW, how would you feel about adding Issues to this GitHub repo? Might make it easier to propose and discuss changes before opening PRs.